### PR TITLE
Implements the `pre-commit` cli command

### DIFF
--- a/src/bin/imgix/commands/mod.rs
+++ b/src/bin/imgix/commands/mod.rs
@@ -1,7 +1,11 @@
 use imgix::command_prelude::*;
 
+/// This function exists to export the cli configuration for all sub
+/// commands. It works by populating a `Vec` with clap `App`s. Each
+/// `App` defines the command line interface (cli) for _it's module_.
 pub fn all_sub_commands() -> Vec<App> {
-    vec![init::cli()]
+    vec![init::cli(), pre_commit::cli()]
 }
 
 pub mod init;
+pub mod pre_commit;

--- a/src/bin/imgix/commands/pre_commit.rs
+++ b/src/bin/imgix/commands/pre_commit.rs
@@ -1,0 +1,70 @@
+use imgix::command_prelude::{App, SubCommand};
+use std::io::{self, Write};
+
+/// Returns the `SubCommand` associated with `pre-commit`. This
+/// function can be invoked through the imgix-cli like so:
+pub fn cli() -> App {
+    SubCommand::with_name("pre-commit").about("Set up git pre-commit configuration.")
+}
+
+/// Executes the `pre-commit` command.
+///
+/// This function _does not_ modify any directory or file structure. This
+/// function writes instructions and code to stdout. The instructions are
+/// to copy the accompanying code and paste it in `.git/hooks/pre-commit`.
+///
+/// This command can be extended to support functionality from passing a
+/// flag to the pre-commit sub-command like so: `imgix pre-commit --write`
+/// This way we avoid writing anything to disk that isn't wanted or warranted.
+pub fn exec() -> io::Result<()> {
+    let pre_commit_body = r#"
+Hey! Thanks for using this pre-commit hook! Your future-self thanks you.
+
+In this git repository there's a directory named `.git` and it contains 
+a `hooks` directory that contains executable files:
+
+.git
+├── hooks
+    ├── pre-commit
+    └── other-stuff
+
+Create your own `pre-commit` file if one does not already exist:
+
+    `$ touch .git/hooks/pre-commit`
+
+Place the following code in .git/hooks/pre-commit. Note: you may have to
+
+    `$ chmod +x .git/hooks/pre-commit`
+
+before the file is executable.
+
+#!/bin/sh
+#
+# Pre-commit hooks for imgix-rs.
+# 
+# This hook is meant to be helpful. It is not meant to hinder you or
+# annoy you. Since this is a client side (and not a git-enforced
+# policy), you can delete this at any time, at your own risk.
+#
+# You can also invoke git commit as:
+#
+# `% git commit --no-verify`
+#
+# This option bypasses the pre-commit and commit-msg hooks.
+
+
+# Prior to committing, do the following:
+
+# Build for release.
+cargo build --release
+
+# Format the repository.
+cargo fmt
+
+# Test the repository.
+cargo test 
+
+"#;
+    io::stdout().write_all(pre_commit_body.as_bytes())?;
+    Ok(())
+}

--- a/src/bin/imgix/main.rs
+++ b/src/bin/imgix/main.rs
@@ -14,6 +14,16 @@ fn main() -> Result<()> {
 /// maps a given command to _its_ executor.
 fn run(app: clap::App<'static, 'static>) -> Result<()> {
     match app.get_matches().subcommand() {
+        ("pre-commit", Some(_)) => match commands::pre_commit::exec() {
+            Ok(_) => Ok(()),
+            Err(e) => Ok(eprintln!(
+                r#"
+info: `pre-commit` failed with
+ {error}
+"#,
+                error = e
+            )),
+        },
         _ => {
             exit(1);
         }


### PR DESCRIPTION
Implements the `pre-commit` cli command

The new `pre-commit` command can be invoked from the imgix command
line interface (cli) by writing:

```bash
$ imgix pre-commit
```

This command writes a string to stdout. This string contains:

- a set of instructions and
- a short bash script

The instructions are to "copy and paste" the bash script into the
`.git/hooks/pre-commit` file for this repo.

The code to-be-written to the pre-commit file is to:

- help keep this codebase consistently formatted *__and__* tested and
- save typing and time (i.e. use the hook instead of always writing
  `cargo fmt && cargo build --release && cargo test`)
- manually invoking the above commands __is still encouraged__, but
  - this hook can help make sure we never push unformatted code

The `pre-commit` command was implemented in the cli itself because it
provided a natural way to distribute client-side logic & functionality
that users could opt into. If you have this code, you have the hook.
This implementation also allows for the functionality to be
__discovered__ by invoking `$ imgix help`.

This command seeks to be transparent in what it does, i.e. a string is
written to stdout and __nothing is written to disk__. This crate seeks
to provide magic that matches the spells. That is, users should get
what they asked for––no surprises, no side-effects. To be clear, 
explicit is better than implicit.

This command can be __extended__ in the future by adding a flag or an
argument to its `cli`. A future call could look like:

```bash
$ imgix pre-commit --write-to-disk
```

Or,

```bash
$ imgix pre-commit --write-to=".git/hooks/pre-commit"
```

The process to create this command followed a pattern. The pattern is:

- define a command-line interface for the command (in `commands/`)
  - i.e. `fn cli() -> App`
- define the code to be executed when the command is invoked
  - i.e. `fn exec() -> Result<()>`
- define an appropriate test, in this case, I chose not to test the
  output (this gets trickier across platform)
- plug the command into `all_sub_commands`
- match on the sub-command in `main.rs` and `exec`ute
